### PR TITLE
feat: Add Dynamic Contributors Section

### DIFF
--- a/website/contribute.html
+++ b/website/contribute.html
@@ -81,11 +81,23 @@
             <a href="https://github.com/Shubham-cyber-prog/100-days-of-web-development/blob/main/CONTRIBUTING.md"
                 class="btn" target="_blank">Read Full Guidelines</a>
         </div>
+
+        <section>
+            <h2>✨ Hall of Fame</h2>
+            <p style="color: var(--text-secondary); margin-bottom: 2rem;">
+                A huge thanks to all the amazing developers who have contributed to this journey!
+            </p>
+            <div id="contributors-grid" class="contributors-grid">
+                <p>Loading contributors...</p>
+            </div>
+        </section>
+
     </main>
 
     <footer>
         <p>Maintained by the Shubham-cyber-prog</p>
     </footer>
+    <script src="contributors.js"></script>
 </body>
 
 </html>

--- a/website/contributors.js
+++ b/website/contributors.js
@@ -1,0 +1,33 @@
+const repoOwner = "Shubham-cyber-prog"; 
+const repoName = "100-Days-Of-Web-Development";
+const container = document.getElementById("contributors-grid");
+
+async function fetchContributors() {
+    try {
+        const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contributors`);
+        if (!response.ok) throw new Error("Failed to fetch contributors");
+        
+        const contributors = await response.json();
+        container.innerHTML = ""; // Clear the loading text
+
+        contributors.forEach(user => {
+            const card = document.createElement("a");
+            card.href = user.html_url;
+            card.target = "_blank";
+            card.className = "contributor-card";
+
+            card.innerHTML = `
+                <img src="${user.avatar_url}" alt="${user.login}" class="contributor-img">
+                <span class="contributor-name">${user.login}</span>
+                <span class="contributor-commits">${user.contributions} contributions</span>
+            `;
+
+            container.appendChild(card);
+        });
+    } catch (error) {
+        container.innerHTML = `<p style="color: #ef4444;">Unable to load contributors at this time.</p>`;
+        console.error(error);
+    }
+}
+
+document.addEventListener("DOMContentLoaded", fetchContributors);

--- a/website/style.css
+++ b/website/style.css
@@ -462,3 +462,57 @@ footer {
 .code-block:hover {
     cursor: text;
 }
+
+/* Contributors Grid */
+.contributors-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    justify-content: center;
+    margin-top: 1rem;
+}
+
+.contributor-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    text-align: center;
+    width: 160px;
+    transition: transform var(--transition-speed), border-color var(--transition-speed);
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.contributor-card:hover {
+    transform: translateY(-5px);
+    border-color: var(--accent-primary);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+}
+
+.contributor-img {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    margin-bottom: 1rem;
+    border: 2px solid var(--accent-primary);
+    object-fit: cover;
+}
+
+.contributor-name {
+    color: var(--text-primary);
+    font-weight: 600;
+    font-size: 0.9rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 100%;
+}
+
+.contributor-commits {
+    color: var(--badge-beginner); /* Using your green variable */
+    font-size: 0.8rem;
+    margin-top: 0.25rem;
+}


### PR DESCRIPTION
## Description
This PR adds a "Hall of Fame" section to the `contribute.html` page. 

## Changes Implemented
- Added HTML structure for the contributors grid in `contribute.html`.
- Created `website/contributors.js` to fetch contributor data from the GitHub API automatically.
- Added CSS styling in `style.css` to display contributor cards with avatars and commit counts.

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ac2bad7e-de52-43b5-b519-0f2a6b4472bf" />


## Checklist
- [x] Code works locally
- [x] Styles match the project theme

Fixes: #29 
**ECWOC LV-3**