### PR TITLE
Project Section of Website improved

### DIFF
--- a/website/scripts/pages/projects.js
+++ b/website/scripts/pages/projects.js
@@ -140,15 +140,32 @@ function renderProjects(filter = 'All') {
                 ${techTags}
             </div>
 
-            <div class="flex gap-4 mt-auto">
-                <a href="${liveLink}" class="btn btn-primary ${isDisabled ? 'disabled' : ''}" 
-                   style="flex: 1; justify-content: center; font-size: 0.9rem; opacity: ${isDisabled ? '0.5' : '1'}; pointer-events: ${isDisabled ? 'none' : 'auto'};">
+                <div class="flex gap-4 mt-auto">
+                    <a href="${liveLink}"
+                    class="btn"
+                    style="
+                        flex: 1;
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                        font-size: 0.9rem;
+                        padding: 10px 14px;
+                        border-radius: 10px;
+                        background-color: ${isDisabled ? '#FFE0C2' : '#FF7A18'};
+                        color: ${isDisabled ? '#9A5A1C' : '#FFFFFF'};
+                        font-weight: 500;
+                        opacity: ${isDisabled ? '0.6' : '1'};
+                        pointer-events: ${isDisabled ? 'none' : 'auto'};
+                        text-decoration: none;
+                        transition: all 0.2s ease;
+                    ">
                     ${isDisabled ? 'Pending' : 'Live Demo'}
-                </a>
-                <a href="${codeLink}" target="_blank" class="btn btn-social" style="flex: 1; justify-content: center; font-size: 0.9rem;">
-                    View Code
-                </a>
-            </div>
+                    </a>
+
+                    <a href="${codeLink}" target="_blank" class="btn btn-social" style="flex: 1; justify-content: center; font-size: 0.9rem;">
+                        View Code
+                    </a>
+                </div>
         `;
 
         setupTiltEffect(card); // Attach 3D Tilt Logic


### PR DESCRIPTION
## Fix: Make Live Demo button visible using inline styles

###  Problem
The **“Live Demo / Pending”** button on project cards was not visible due to
conflicting global styles applied by the existing `.btn` / `.btn-primary` classes.
Even with inline styles, the button appeared transparent or blended into the card background.

---

### Solution
- Removed dependency on conflicting button classes
- Applied **fully inline styles** to ensure:
  - Proper background color
  - Readable text color
  - Clear disabled (`Pending`) state
- No external CSS file was added

---

### Screenshots

Before:
<img width="1666" height="801" alt="Screenshot 2026-01-09 020528" src="https://github.com/user-attachments/assets/3c591fd4-2737-4e78-a934-34036a1095ff" />
<img width="1674" height="797" alt="Screenshot 2026-01-09 020545" src="https://github.com/user-attachments/assets/9f202c87-89ae-4b9c-ad06-306dc843be65" />

After:
<img width="1652" height="720" alt="Screenshot 2026-01-09 020647" src="https://github.com/user-attachments/assets/0647ec7d-0e10-4fd0-a4e3-1a4b36bf65f4" />
<img width="1700" height="709" alt="Screenshot 2026-01-09 020655" src="https://github.com/user-attachments/assets/7996237e-c912-4002-9a42-7f9ac55337cd" />
