### PR TITLE
Fix platform links(Github,Discord)

### DIFF
--- a/website/pages/dashboard.html
+++ b/website/pages/dashboard.html
@@ -281,7 +281,7 @@
                 <h3>Connect</h3>
                 <p class="text-secondary text-sm mb-4">Join the signal frequency.</p>
                 <div class="footer-socials">
-                    <a href="#" class="social-btn" aria-label="Github"><svg class="icon" viewBox="0 0 24 24">
+                    <a href="https://github.com/Shubham-cyber-prog/100-Days-Of-Web-Development-ECWoC26" class="social-btn" aria-label="Github"><svg class="icon" viewBox="0 0 24 24">
                             <path
                                 d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22">
                             </path>
@@ -291,7 +291,7 @@
                                 d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z">
                             </path>
                         </svg></a>
-                    <a href="#" class="social-btn" aria-label="Discord"><svg class="icon" viewBox="0 0 24 24">
+                    <a href="https://discord.gg/UzPBtXqMr" class="social-btn" aria-label="Discord"><svg class="icon" viewBox="0 0 24 24">
                             <path
                                 d="M21 2H3c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM9 14l-2 2v-5l2-2v5zm11 0l-2 2v-5l2-2v5z">
                             </path>


### PR DESCRIPTION
Describe the bug:
The links on the homepage (GitHub, Twitter, and Discord) are not functioning correctly. Clicking these icons does not redirect users to the respective platforms, which breaks expected navigation and reduces usability.

To Reproduce
Steps to reproduce the behavior:
- Open the homepage of the website.
- Scroll to the section containing the social media icons.
- Click on the GitHub, Twitter, or Discord icon.
- Observe that the links do not open the correct pages.

Expected behavior
Clicking on each social media icon should redirect the user to the corresponding official page in a new browser tab.

Desktop:
- OS: Windows 10 / macOS
- Browser: Chrome
- Version: Latest
- Smartphone

Device: Android phone
OS: Android 12+
Browser: Chrome
Version: Latest

Additional context
Fixing these links will improve user experience by ensuring visitors can easily access the project’s official GitHub, Twitter, and Discord pages. I would like to work on this issue and submit a pull request to correct the broken links.