### PR TITLE
docs: clarify git add usage for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Welcome to the **100 Days of Web Development** challenge! Follow these steps to 
    git commit -m "Add brief description of your changes"
    git push origin feature/your-feature-name
    ```
+   > **Note:** `git add .` stages **all modified and untracked files** in the repository.
+>  
+> If you want to stage only a specific file, you can use:
+> ```bash
+> git add <filename>
+> ```
+>  
+> This can help avoid accidentally committing unrelated changes.
 8. **Create a Pull Request**: Go to the original repository and create a PR with a clear description.
 
 ### Additional Tips


### PR DESCRIPTION
## What does this PR do?

This pull request adds a small clarification for beginners regarding the usage of the `git add` command.

## Why is this change needed?

Beginners often use `git add .` without understanding that it stages all modified files.  
This clarification helps contributors avoid accidentally committing unrelated changes by explaining how to stage a specific file using `git add <filename>`.

## Type of change

- [x] Documentation improvement
- [ ] Bug fix
- [ ] New feature

## Additional notes

This change does not alter existing functionality and only improves clarity in the contribution guide.