### PR TITLE
Continue without signing in button removed

### DIFF
--- a/website/pages/login.html
+++ b/website/pages/login.html
@@ -142,10 +142,7 @@
                 style="display: block; margin-top: var(--space-4); font-size: 0.85rem; color: var(--text-tertiary);">Forgot
                 Access Code?</a>
 
-            <button onclick="handleGuestLogin()" class="btn btn-ghost"
-                style="width: 100%; margin-top: var(--space-6); font-size: 0.85rem; color: var(--text-secondary); border: 1px dashed var(--glass-border);">
-                Continue without signing in
-            </button>
+            <!-- Guest access removed to enforce signup/signin flow -->
         </div>
     </div>
 

--- a/website/scripts/auth/guard.js
+++ b/website/scripts/auth/guard.js
@@ -15,7 +15,8 @@
 
     const currentPath = window.location.pathname;
     const isLoginPage = currentPath.includes('login.html');
-    const isAuthenticated = sessionStorage.getItem('authToken') === 'true';
+    const isGuest = sessionStorage.getItem('authGuest') === 'true';
+    const isAuthenticated = sessionStorage.getItem('authToken') === 'true' && !isGuest;
 
     // 1. If not authenticated and trying to access a protected page
     if (!isAuthenticated) {
@@ -44,6 +45,8 @@
                     }
                 }
 
+                // If a guest token exists, force removal to prevent bypass
+                if (isGuest) sessionStorage.removeItem('authGuest');
                 window.location.href = loginPath;
             }
         }

--- a/website/scripts/auth/service.js
+++ b/website/scripts/auth/service.js
@@ -32,14 +32,4 @@ function handleEmailLogin(e) {
     }, 1000);
 }
 
-function handleGuestLogin() {
-    const btn = event.currentTarget;
-    btn.innerText = 'Bypassing Security...';
-    btn.style.opacity = '0.7';
-
-    setTimeout(() => {
-        sessionStorage.setItem('authToken', 'true');
-        sessionStorage.setItem('authGuest', 'true');
-        window.location.href = 'dashboard.html';
-    }, 800);
-}
+// Guest login removed: no handleGuestLogin() provided to prevent bypass.


### PR DESCRIPTION
This pull request enforces proper user authentication across the application and removes the option for users to bypass the login system.

Changes included:

Removed “Continue without signing in” option from the login page to prevent unauthorized access.

Enforced authentication checks on all pages that require users to be signed in.

Users who are not logged in are redirected to the login page.

Reason for changes:
Allowing users to skip login can lead to unauthorized access, inconsistent user data, and security risks. This PR ensures that all users must sign up and log in before accessing the application.

Testing instructions:

Try accessing any authenticated page without logging in → should redirect to login page.

Verify the “Continue without signing in” option is no longer visible.

Closes : #605
Fixes: #605