### PR TITLE
fix(cursor): remove liquid flame trail effects

### DIFF
--- a/website/styles/components/cursor.css
+++ b/website/styles/components/cursor.css
@@ -135,3 +135,9 @@ body {
         display: none !important;
     }
 }
+
+#cursor-trail-container,
+#cursor-trail-container .trail-segment {
+    display: none !important;
+    pointer-events: none !important;
+}


### PR DESCRIPTION
- Removed liquid flame trail effect from the site.
- Restored default system arrow cursor.
- #cursor-trail-container and all trail segments are hidden by default.
- Accessibility and fallback considerations retained:
  - Disabled for coarse pointers (touch devices).
  - Disabled for users preferring reduced motion.
  fixed: #592  