### PR TITLE
Index Page UI Fixed in Light Mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,14 @@
             width: 100%;
         }
 
+        /* Navbar in light mode */
+        html[data-theme="light"] .site-header {
+            background: var(--light-bg);
+            backdrop-filter: blur(0); /* remove glass mismatch */
+            -webkit-backdrop-filter: blur(0);
+            box-shadow: none;
+        
+        }
         /* Hero Section Enhancement */
         .zenith-hero {
             text-align: center;
@@ -159,6 +167,10 @@
             line-height: 1.6;
             position: relative;
             z-index: 1;
+        }
+
+        html[data-theme="light"] .hero-subtitle {
+            color: #333;
         }
 
         .hero-actions {
@@ -222,6 +234,10 @@
             border-color: rgba(102, 126, 234, 0.8);
             transform: translateY(-3px);
             box-shadow: var(--shadow-md);
+        }
+
+        html[data-theme="light"] .btn-zenith-secondary{
+            color:#333;
         }
 
         /* Feature Cards Enhancement */

--- a/website/styles/base/global.css
+++ b/website/styles/base/global.css
@@ -56,3 +56,8 @@ h6 {
 ::-webkit-scrollbar-thumb:hover {
     background: var(--text-tertiary);
 }
+
+html[data-theme="light"] body {
+    background: #f9fafb;
+    color: #111;
+}

--- a/website/styles/components/cards.css
+++ b/website/styles/components/cards.css
@@ -387,3 +387,9 @@
     </div>
   </div>
 */
+
+/* cards in light mode */
+html[data-theme="light"] .feature-card h3,
+html[data-theme="light"] .feature-card p {
+  color: #111827;
+}

--- a/website/styles/components/footer.css
+++ b/website/styles/components/footer.css
@@ -205,3 +205,58 @@
         text-align: center;
     }
 }
+
+/* footer Light mode */
+html[data-theme="light"] .site-footer {
+    background: rgba(255, 255, 255, 0.9);
+    border-top: 1px solid rgba(0, 0, 0, 0.08);
+    color: #1f2937;
+}
+
+html[data-theme="light"] .footer-content {
+    color: #1f2937;
+}
+
+html[data-theme="light"] .footer-brand h2,
+html[data-theme="light"] .footer-col h3 {
+    color: #111827;
+}
+
+html[data-theme="light"] .footer-desc,
+html[data-theme="light"] .text-secondary {
+    color: #4b5563;
+}
+
+html[data-theme="light"] .footer-link {
+    color: #374151;
+}
+
+html[data-theme="light"] .footer-link:hover {
+    color: #6366f1; 
+}
+
+html[data-theme="light"] .footer-link::before {
+    color: #6366f1;
+}
+
+html[data-theme="light"] .social-btn {
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+html[data-theme="light"] .social-btn:hover {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    box-shadow: 0 10px 25px rgba(99, 102, 241, 0.3);
+}
+
+html[data-theme="light"] .footer-bottom {
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+html[data-theme="light"] .footer-bottom p {
+    color: #6b7280;
+}
+
+html[data-theme="light"] .heart-pulse {
+    color: #ef4444;
+}


### PR DESCRIPTION
Description:- 
Earlier, the in the Light mode, the theme of the index page was not changing into the light mode, as a result it was always in the dark mode. 
Now, the theme toggle is shifted to the light mode then the theme of the website changes to the light mode.

Issue resolved:- #913 

Images of the index page in the light mode( when the theme toggle is shifted to the light mode):-
<img width="1366" height="684" alt="image" src="https://github.com/user-attachments/assets/184bd94e-0bec-4e10-a9d7-061a345fa839" />
<img width="1366" height="641" alt="image" src="https://github.com/user-attachments/assets/d0afde8e-a666-48ca-b9e5-e184bfa30796" />
<img width="1366" height="685" alt="image" src="https://github.com/user-attachments/assets/cbe2d4cc-50dd-4e13-b9ce-18fca53e9677" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Added comprehensive light theme styling for all major UI components, including navigation, hero section, cards, and footer, with optimized colors and visual effects for improved visibility in light mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->