### PR TITLE
Fixed unnecessary text displayed near navbar

### DIFF
--- a/website/pages/leaderboard.html
+++ b/website/pages/leaderboard.html
@@ -497,14 +497,14 @@
     </header>
 
     <!-- Mobile Menu -->
-    <div class="mobile-menu" id="mobileMenu">
+    <!-- <div class="mobile-menu" id="mobileMenu">
         <a href="dashboard.html" class="mobile-link">Dashboard</a>
         <a href="projects.html" class="mobile-link">Projects</a>
         <a href="leaderboard.html" class="mobile-link active">Leaderboard</a>
         <a href="about.html" class="mobile-link">About</a>
         <a href="contributors.html" class="mobile-link">Contributors</a>
         <a href="login.html" class="mobile-link" id="logoutBtn">Logout</a>
-    </div>
+    </div> -->
 
     <main>
         <!-- Hero Section -->


### PR DESCRIPTION
Unnecessary Content Displayed Near Navbar on Leaderboard Page #935

@Shubham-cyber-prog 

# before
<img width="1813" height="324" alt="image" src="https://github.com/user-attachments/assets/f70c9b63-000d-45cb-a3ac-4643f8fcaa19" />

# after
<img width="1819" height="268" alt="image" src="https://github.com/user-attachments/assets/f2c65fd4-8400-4b55-b91b-c9d5d6126f49" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the mobile menu from the leaderboard page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->