### PR TITLE
Day 61 GraphQL setup using Apollo Server

### DIFF
--- a/public/Day 61/src/server/dist/graphql/index.js
+++ b/public/Day 61/src/server/dist/graphql/index.js
@@ -1,0 +1,52 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.configureGraphQL = configureGraphQL;
+const cors_1 = __importDefault(require("cors"));
+const body_parser_1 = __importDefault(require("body-parser"));
+const server_1 = require("@apollo/server");
+const express4_1 = require("@apollo/server/express4");
+const client_1 = require("@prisma/client");
+const schema_1 = require("./v1/schema");
+const prisma = new client_1.PrismaClient();
+function configureGraphQL(app) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const apolloServer = new server_1.ApolloServer({
+            schema: schema_1.combinedSchemas,
+        });
+        yield apolloServer.start();
+        app.use("/api/v1/graphql", (0, cors_1.default)({
+            origin: process.env.NODE_ENV === "production"
+                ? ["https://ecommerce-nu-rosy.vercel.app"]
+                : ["http://localhost:3000", "http://localhost:5173"],
+            credentials: true,
+            methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+            allowedHeaders: [
+                "Content-Type",
+                "Authorization",
+                "X-Requested-With",
+                "Apollo-Require-Preflight",
+            ],
+        }), body_parser_1.default.json(), (0, express4_1.expressMiddleware)(apolloServer, {
+            context: (_a) => __awaiter(this, [_a], void 0, function* ({ req, res }) {
+                return ({
+                    req,
+                    res,
+                    prisma,
+                    user: req.user,
+                });
+            }),
+        }));
+    });
+}

--- a/public/Day 61/src/server/dist/graphql/v1/index.js
+++ b/public/Day 61/src/server/dist/graphql/v1/index.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.serverV1 = void 0;
+const server_1 = require("@apollo/server");
+const schema_1 = require("./schema");
+exports.serverV1 = new server_1.ApolloServer({
+    schema: schema_1.combinedSchemas,
+    introspection: process.env.NODE_ENV !== "production",
+    includeStacktraceInErrorResponses: process.env.NODE_ENV !== "production",
+});

--- a/public/Day 61/src/server/dist/graphql/v1/schema.js
+++ b/public/Day 61/src/server/dist/graphql/v1/schema.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.combinedSchemas = void 0;
+const schema_1 = require("@/modules/analytics/graphql/schema");
+const schema_2 = require("@/modules/product/graphql/schema");
+const schema_3 = require("@graphql-tools/schema");
+exports.combinedSchemas = (0, schema_3.mergeSchemas)({
+    schemas: [schema_1.analyticsSchema, schema_2.productSchema],
+});

--- a/public/Day 61/src/server/dist/graphql/v2/index.js
+++ b/public/Day 61/src/server/dist/graphql/v2/index.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.serverV2 = void 0;
+const server_1 = require("@apollo/server");
+const schema_1 = require("../v1/schema");
+exports.serverV2 = new server_1.ApolloServer({
+    schema: schema_1.combinedSchemas,
+    introspection: process.env.NODE_ENV !== "production",
+    includeStacktraceInErrorResponses: process.env.NODE_ENV !== "production",
+});

--- a/public/Day 61/src/server/dist/graphql/v2/schema.js
+++ b/public/Day 61/src/server/dist/graphql/v2/schema.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.combinedSchemas = void 0;
+const schema_1 = require("@graphql-tools/schema");
+exports.combinedSchemas = (0, schema_1.mergeSchemas)({
+    schemas: [],
+});


### PR DESCRIPTION
This Pull Request introduces the initial GraphQL setup using Apollo Server 4 and Express. It establishes a scalable architecture for API versioning (v1/v2) and integrates Prisma as the primary ORM within the GraphQL context.

Key Changes
1. Apollo Server Integration

- Implemented the configureGraphQL function to initialize and start the Apollo Server.
- Mounted the GraphQL endpoint at /api/v1/graphql using expressMiddleware.

2. Security & Middleware

- CORS Configuration: Added specific origin checks to allow requests from the production frontend (ecommerce-nu-rosy.vercel.app) and local development environments (localhost:3000, localhost:5173).
- Preflight Support: Included Apollo-Require-Preflight in allowed headers to ensure compatibility with Apollo’s CSRF protection.

3. Context & Database

- Configured the GraphQL context to provide universal access to:
- Prisma Client: For seamless database queries within resolvers.
- User Session: Injected req.user into the context for authentication-dependent logic.
- Request/Response objects: For low-level header or cookie manipulation if needed.

4. Schema Management

- Initialized schema.js using @graphql-tools/schema.
- Set up mergeSchemas to allow for modularized type definitions and resolvers as the project grows.