### PR TITLE
feat: Implement Markdown to PDF/HTML Converter & Editor 

### DIFF
--- a/Tools/markdown-editor/index.html
+++ b/Tools/markdown-editor/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MarkWrite - Markdown Editor</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;500;600;700&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+
+    <link rel="stylesheet" href="./styles/editor.css">
+    <link rel="stylesheet" href="./styles/print.css" media="print">
+</head>
+
+<body>
+    <div class="app-container">
+        <!-- Header with Toolbar -->
+        <header class="editor-header">
+            <div class="brand">
+                <i class="fa-brands fa-markdown"></i>
+                <h1>MarkWrite</h1>
+                <span class="auto-save-status" id="save-status">All changes saved</span>
+            </div>
+
+            <div class="toolbar">
+                <div class="toolbar-group">
+                    <button class="tool-btn" data-action="bold" title="Bold (Ctrl+B)">
+                        <i class="fa-solid fa-bold"></i>
+                    </button>
+                    <button class="tool-btn" data-action="italic" title="Italic (Ctrl+I)">
+                        <i class="fa-solid fa-italic"></i>
+                    </button>
+                    <button class="tool-btn" data-action="strikethrough" title="Strikethrough">
+                        <i class="fa-solid fa-strikethrough"></i>
+                    </button>
+                </div>
+
+                <div class="toolbar-divider"></div>
+
+                <div class="toolbar-group">
+                    <button class="tool-btn" data-action="heading" title="Heading">
+                        <i class="fa-solid fa-heading"></i>
+                    </button>
+                    <button class="tool-btn" data-action="link" title="Insert Link (Ctrl+K)">
+                        <i class="fa-solid fa-link"></i>
+                    </button>
+                    <button class="tool-btn" data-action="image" title="Insert Image">
+                        <i class="fa-solid fa-image"></i>
+                    </button>
+                    <button class="tool-btn" data-action="code" title="Code Block">
+                        <i class="fa-solid fa-code"></i>
+                    </button>
+                </div>
+
+                <div class="toolbar-divider"></div>
+
+                <div class="toolbar-group">
+                    <button class="tool-btn" data-action="ul" title="Bullet List">
+                        <i class="fa-solid fa-list-ul"></i>
+                    </button>
+                    <button class="tool-btn" data-action="ol" title="Numbered List">
+                        <i class="fa-solid fa-list-ol"></i>
+                    </button>
+                    <button class="tool-btn" data-action="quote" title="Quote">
+                        <i class="fa-solid fa-quote-left"></i>
+                    </button>
+                </div>
+
+                <div class="toolbar-divider"></div>
+
+                <div class="toolbar-group">
+                    <button class="btn-action" id="btn-download" title="Download Markdown">
+                        <i class="fa-solid fa-download"></i> Download
+                    </button>
+                    <button class="btn-action" id="btn-export-html" title="Export as HTML">
+                        <i class="fa-solid fa-file-code"></i> HTML
+                    </button>
+                    <button class="btn-primary" id="btn-print" title="Print / Save as PDF">
+                        <i class="fa-solid fa-print"></i> Print PDF
+                    </button>
+                </div>
+            </div>
+        </header>
+
+        <!-- Main Split View -->
+        <main class="editor-workspace">
+            <div class="editor-pane">
+                <div class="pane-header">
+                    <span>Markdown</span>
+                    <div class="editor-stats">
+                        <span id="word-count">0 words</span>
+                        <span id="char-count">0 characters</span>
+                    </div>
+                </div>
+                <textarea id="markdown-input" placeholder="# Start writing your markdown here...
+
+**Bold** and *italic* text
+- List items
+1. Numbered items
+[Links](https://example.com)
+`inline code`
+
+```
+code blocks
+```
+" spellcheck="false"></textarea>
+            </div>
+
+            <div class="resize-divider" id="resize-divider"></div>
+
+            <div class="preview-pane">
+                <div class="pane-header">
+                    <span>Preview</span>
+                    <label class="sync-toggle">
+                        <input type="checkbox" id="sync-scroll" checked>
+                        <span>Sync Scroll</span>
+                    </label>
+                </div>
+                <div id="preview-content" class="markdown-body">
+                    <p class="placeholder">Preview will appear here...</p>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script type="module" src="./scripts/main.js"></script>
+</body>
+
+</html>

--- a/Tools/markdown-editor/scripts/core/parser.js
+++ b/Tools/markdown-editor/scripts/core/parser.js
@@ -1,0 +1,213 @@
+/**
+ * Custom Markdown Parser
+ * Converts Markdown to HTML using regex replacements
+ * No external libraries - pure vanilla JS implementation
+ */
+
+export class MarkdownParser {
+    constructor() {
+        // Store original text for reference
+        this.originalText = '';
+    }
+
+    /**
+     * Main parse method
+     * @param {string} markdown - Raw markdown text
+     * @returns {string} - HTML output
+     */
+    parse(markdown) {
+        if (!markdown) return '';
+
+        this.originalText = markdown;
+        let html = markdown;
+
+        // Process in specific order to avoid conflicts
+
+        // 1. Code blocks (must be done first to protect code content)
+        html = this.parseCodeBlocks(html);
+
+        // 2. Headers
+        html = this.parseHeaders(html);
+
+        // 3. Horizontal rules
+        html = this.parseHorizontalRules(html);
+
+        // 4. Blockquotes
+        html = this.parseBlockquotes(html);
+
+        // 5. Lists (ordered and unordered)
+        html = this.parseLists(html);
+
+        // 6. Inline elements (bold, italic, strikethrough)
+        html = this.parseInline(html);
+
+        // 7. Links and images
+        html = this.parseLinks(html);
+        html = this.parseImages(html);
+
+        // 8. Inline code
+        html = this.parseInlineCode(html);
+
+        // 9. Line breaks and paragraphs
+        html = this.parseParagraphs(html);
+
+        return html;
+    }
+
+    /**
+     * Parse code blocks (```)
+     */
+    parseCodeBlocks(text) {
+        // Match code blocks with optional language
+        return text.replace(/```(\w+)?\n([\s\S]*?)```/g, (match, lang, code) => {
+            const escapedCode = this.escapeHtml(code.trim());
+            return `<pre><code class="language-${lang || 'plaintext'}">${escapedCode}</code></pre>`;
+        });
+    }
+
+    /**
+     * Parse inline code (`)
+     */
+    parseInlineCode(text) {
+        // Avoid matching within code blocks
+        return text.replace(/`([^`\n]+)`/g, '<code>$1</code>');
+    }
+
+    /**
+     * Parse headers (#)
+     */
+    parseHeaders(text) {
+        // H1-H6
+        return text.replace(/^(#{1,6})\s+(.+)$/gm, (match, hashes, content) => {
+            const level = hashes.length;
+            return `<h${level}>${content.trim()}</h${level}>`;
+        });
+    }
+
+    /**
+     * Parse horizontal rules (---, ***, ___)
+     */
+    parseHorizontalRules(text) {
+        return text.replace(/^(\*{3,}|-{3,}|_{3,})$/gm, '<hr>');
+    }
+
+    /**
+     * Parse blockquotes (>)
+     */
+    parseBlockquotes(text) {
+        // Handle multi-line quotes
+        return text.replace(/^>\s+(.+)$/gm, '<blockquote>$1</blockquote>');
+    }
+
+    /**
+     * Parse lists (ordered and unordered)
+     */
+    parseLists(text) {
+        // Unordered lists
+        text = text.replace(/^[\*\-\+]\s+(.+)$/gm, '<li>$1</li>');
+
+        // Wrap consecutive <li> in <ul>
+        text = text.replace(/(<li>.*<\/li>\n?)+/g, (match) => {
+            return `<ul>\n${match}</ul>\n`;
+        });
+
+        // Ordered lists
+        text = text.replace(/^\d+\.\s+(.+)$/gm, '<li>$1</li>');
+
+        // This is simplified - in reality we'd need better detection
+        // For now, assume numbered lists are separate from bullet lists
+
+        return text;
+    }
+
+    /**
+     * Parse inline formatting (bold, italic, strikethrough)
+     */
+    parseInline(text) {
+        // Bold (**text** or __text__)
+        text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+        text = text.replace(/__(.+?)__/g, '<strong>$1</strong>');
+
+        // Italic (*text* or _text_) - must be after bold
+        text = text.replace(/\*(.+?)\*/g, '<em>$1</em>');
+        text = text.replace(/_(.+?)_/g, '<em>$1</em>');
+
+        // Strikethrough (~~text~~)
+        text = text.replace(/~~(.+?)~~/g, '<del>$1</del>');
+
+        return text;
+    }
+
+    /**
+     * Parse links [text](url)
+     */
+    parseLinks(text) {
+        return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+    }
+
+    /**
+     * Parse images ![alt](url)
+     */
+    parseImages(text) {
+        return text.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">');
+    }
+
+    /**
+     * Parse paragraphs (double line break = new paragraph)
+     */
+    parseParagraphs(text) {
+        const lines = text.split('\n');
+        let inParagraph = false;
+        let result = [];
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i].trim();
+
+            // Skip if line is already wrapped in HTML tag
+            if (line.startsWith('<') || line === '') {
+                if (inParagraph) {
+                    result.push('</p>');
+                    inParagraph = false;
+                }
+                result.push(lines[i]);
+            } else {
+                if (!inParagraph) {
+                    result.push('<p>');
+                    inParagraph = true;
+                }
+                result.push(line);
+            }
+        }
+
+        if (inParagraph) {
+            result.push('</p>');
+        }
+
+        return result.join('\n');
+    }
+
+    /**
+     * Escape HTML to prevent XSS
+     */
+    escapeHtml(text) {
+        const map = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;'
+        };
+        return text.replace(/[&<>"']/g, (m) => map[m]);
+    }
+
+    /**
+     * Calculate statistics
+     */
+    getStats(markdown) {
+        const words = markdown.trim().split(/\s+/).filter(w => w.length > 0).length;
+        const chars = markdown.length;
+        const lines = markdown.split('\n').length;
+
+        return { words, chars, lines };
+    }
+}

--- a/Tools/markdown-editor/scripts/main.js
+++ b/Tools/markdown-editor/scripts/main.js
@@ -1,0 +1,161 @@
+/**
+ * Main Application Entry Point
+ * Initializes and coordinates all modules
+ */
+
+import { MarkdownParser } from './core/parser.js';
+import { Toolbar } from './ui/toolbar.js';
+import { PDFExporter, HTMLExporter } from './utils/pdfExport.js';
+import { LocalSaver, DownloadManager } from './utils/localSaver.js';
+
+class MarkWriteApp {
+    constructor() {
+        // Initialize Core Components
+        this.parser = new MarkdownParser();
+        this.toolbar = new Toolbar('markdown-input');
+
+        // Initialize Storage & Downloads
+        this.saver = new LocalSaver('markdown-input');
+        this.downloader = new DownloadManager();
+        this.pdfExport = new PDFExporter();
+        this.htmlExport = new HTMLExporter();
+
+        // UI Elements
+        this.textarea = document.getElementById('markdown-input');
+        this.preview = document.getElementById('preview-content');
+        this.wordCountEl = document.getElementById('word-count');
+        this.charCountEl = document.getElementById('char-count');
+        this.resizer = document.getElementById('resize-divider');
+        this.syncScrollCheckbox = document.getElementById('sync-scroll');
+
+        // State
+        this.isResizing = false;
+
+        this.init();
+    }
+
+    init() {
+        // Initial parse
+        this.updatePreview();
+
+        // Bind Events
+        this.bindEvents();
+    }
+
+    bindEvents() {
+        // Live Rendering
+        this.textarea.addEventListener('input', () => {
+            this.updatePreview();
+        });
+
+        // Synchronized Scrolling
+        this.textarea.addEventListener('scroll', () => {
+            if (this.syncScrollCheckbox.checked) {
+                this.syncScroll();
+            }
+        });
+
+        // Split View Resizing
+        this.resizer.addEventListener('mousedown', (e) => this.startResizing(e));
+        document.addEventListener('mousemove', (e) => this.handleResizing(e));
+        document.addEventListener('mouseup', () => this.stopResizing());
+
+        // Keyboard Shortcuts (Tab support)
+        this.textarea.addEventListener('keydown', (e) => {
+            if (e.key === 'Tab') {
+                e.preventDefault();
+                this.handleTab();
+            }
+        });
+    }
+
+    /**
+     * Update the HTML preview
+     */
+    updatePreview() {
+        const markdown = this.textarea.value;
+        const html = this.parser.parse(markdown);
+
+        // Update DOM
+        this.preview.innerHTML = html || '<p class="placeholder">Preview will appear here...</p>';
+
+        // Update Stats
+        this.updateStats(markdown);
+    }
+
+    /**
+     * Update word and character counts
+     */
+    updateStats(text) {
+        const stats = this.parser.getStats(text);
+        this.wordCountEl.textContent = `${stats.words} ${stats.words === 1 ? 'word' : 'words'}`;
+        this.charCountEl.textContent = `${stats.chars} ${stats.chars === 1 ? 'character' : 'characters'}`;
+    }
+
+    /**
+     * Synchronize scroll position between editor and preview
+     */
+    syncScroll() {
+        const editorScrollRange = this.textarea.scrollHeight - this.textarea.clientHeight;
+        const previewScrollRange = this.preview.scrollHeight - this.preview.clientHeight;
+
+        if (editorScrollRange > 0) {
+            const scrollPercent = this.textarea.scrollTop / editorScrollRange;
+            this.preview.scrollTop = scrollPercent * previewScrollRange;
+        }
+    }
+
+    /**
+     * Handle Tab key for indentation
+     */
+    handleTab() {
+        const start = this.textarea.selectionStart;
+        const end = this.textarea.selectionEnd;
+        const text = this.textarea.value;
+
+        // Insert 4 spaces
+        this.textarea.value = text.substring(0, start) + '    ' + text.substring(end);
+
+        // Set cursor position
+        this.textarea.selectionStart = this.textarea.selectionEnd = start + 4;
+    }
+
+    /**
+     * Start the resizing process
+     */
+    startResizing(e) {
+        this.isResizing = true;
+        document.body.style.cursor = 'col-resize';
+        e.preventDefault();
+    }
+
+    /**
+     * Handle the mouse move during resizing
+     */
+    handleResizing(e) {
+        if (!this.isResizing) return;
+
+        const containerWidth = document.querySelector('.editor-workspace').clientWidth;
+        const percentage = (e.clientX / containerWidth) * 100;
+
+        // Boundary checks (between 20% and 80%)
+        if (percentage >= 20 && percentage <= 80) {
+            document.querySelector('.editor-pane').style.flex = `0 0 ${percentage}%`;
+        }
+    }
+
+    /**
+     * Stop the resizing process
+     */
+    stopResizing() {
+        if (this.isResizing) {
+            this.isResizing = false;
+            document.body.style.cursor = 'default';
+        }
+    }
+}
+
+// Initialize on DOM load
+document.addEventListener('DOMContentLoaded', () => {
+    new MarkWriteApp();
+});

--- a/Tools/markdown-editor/scripts/ui/toolbar.js
+++ b/Tools/markdown-editor/scripts/ui/toolbar.js
@@ -1,0 +1,187 @@
+/**
+ * Toolbar Handler
+ * Manages formatting buttons and text insertion
+ */
+
+export class Toolbar {
+    constructor(textareaId) {
+        this.textarea = document.getElementById(textareaId);
+        this.buttons = document.querySelectorAll('.tool-btn[data-action]');
+        this.init();
+    }
+
+    init() {
+        this.buttons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const action = btn.dataset.action;
+                this.handleAction(action);
+            });
+        });
+
+        // Keyboard shortcuts
+        this.textarea.addEventListener('keydown', (e) => {
+            if (e.ctrlKey || e.metaKey) {
+                switch (e.key.toLowerCase()) {
+                    case 'b':
+                        e.preventDefault();
+                        this.handleAction('bold');
+                        break;
+                    case 'i':
+                        e.preventDefault();
+                        this.handleAction('italic');
+                        break;
+                    case 'k':
+                        e.preventDefault();
+                        this.handleAction('link');
+                        break;
+                }
+            }
+        });
+    }
+
+    handleAction(action) {
+        const actions = {
+            'bold': () => this.wrapText('**', '**'),
+            'italic': () => this.wrapText('*', '*'),
+            'strikethrough': () => this.wrapText('~~', '~~'),
+            'heading': () => this.insertPrefix('## '),
+            'link': () => this.insertLink(),
+            'image': () => this.insertImage(),
+            'code': () => this.insertCodeBlock(),
+            'ul': () => this.insertList('-'),
+            'ol': () => this.insertList('1.'),
+            'quote': () => this.insertPrefix('> ')
+        };
+
+        if (actions[action]) {
+            actions[action]();
+            this.textarea.focus();
+            // Trigger input event to update preview
+            this.textarea.dispatchEvent(new Event('input'));
+        }
+    }
+
+    /**
+     * Wrap selected text with prefix and suffix
+     */
+    wrapText(prefix, suffix) {
+        const start = this.textarea.selectionStart;
+        const end = this.textarea.selectionEnd;
+        const text = this.textarea.value;
+        const selectedText = text.substring(start, end);
+
+        const before = text.substring(0, start);
+        const after = text.substring(end);
+
+        this.textarea.value = before + prefix + selectedText + suffix + after;
+
+        // Set cursor position
+        if (selectedText) {
+            this.textarea.setSelectionRange(start + prefix.length, end + prefix.length);
+        } else {
+            const newPos = start + prefix.length;
+            this.textarea.setSelectionRange(newPos, newPos);
+        }
+    }
+
+    /**
+     * Insert prefix at the start of line
+     */
+    insertPrefix(prefix) {
+        const start = this.textarea.selectionStart;
+        const text = this.textarea.value;
+
+        // Find start of current line
+        let lineStart = text.lastIndexOf('\n', start - 1) + 1;
+
+        const before = text.substring(0, lineStart);
+        const after = text.substring(lineStart);
+
+        this.textarea.value = before + prefix + after;
+
+        const newPos = lineStart + prefix.length;
+        this.textarea.setSelectionRange(newPos, newPos);
+    }
+
+    /**
+     * Insert link
+     */
+    insertLink() {
+        const start = this.textarea.selectionStart;
+        const end = this.textarea.selectionEnd;
+        const text = this.textarea.value;
+        const selectedText = text.substring(start, end);
+
+        const linkText = selectedText || 'link text';
+        const url = prompt('Enter URL:', 'https://');
+
+        if (!url) return;
+
+        const markdown = `[${linkText}](${url})`;
+        const before = text.substring(0, start);
+        const after = text.substring(end);
+
+        this.textarea.value = before + markdown + after;
+
+        const newPos = start + markdown.length;
+        this.textarea.setSelectionRange(newPos, newPos);
+    }
+
+    /**
+     * Insert image
+     */
+    insertImage() {
+        const url = prompt('Enter image URL:', 'https://');
+        const alt = prompt('Enter alt text:', 'image');
+
+        if (!url) return;
+
+        const markdown = `![${alt}](${url})`;
+        this.insertAtCursor(markdown);
+    }
+
+    /**
+     * Insert code block
+     */
+    insertCodeBlock() {
+        const lang = prompt('Enter language (optional):', '');
+        const markdown = `\n\`\`\`${lang}\ncode here\n\`\`\`\n`;
+        this.insertAtCursor(markdown);
+    }
+
+    /**
+     * Insert list item
+     */
+    insertList(prefix) {
+        const start = this.textarea.selectionStart;
+        const text = this.textarea.value;
+
+        // Find start of current line
+        let lineStart = text.lastIndexOf('\n', start - 1) + 1;
+
+        const before = text.substring(0, lineStart);
+        const after = text.substring(lineStart);
+
+        this.textarea.value = before + prefix + ' ' + after;
+
+        const newPos = lineStart + prefix.length + 1;
+        this.textarea.setSelectionRange(newPos, newPos);
+    }
+
+    /**
+     * Insert text at cursor position
+     */
+    insertAtCursor(insertText) {
+        const start = this.textarea.selectionStart;
+        const end = this.textarea.selectionEnd;
+        const text = this.textarea.value;
+
+        const before = text.substring(0, start);
+        const after = text.substring(end);
+
+        this.textarea.value = before + insertText + after;
+
+        const newPos = start + insertText.length;
+        this.textarea.setSelectionRange(newPos, newPos);
+    }
+}

--- a/Tools/markdown-editor/scripts/utils/localSaver.js
+++ b/Tools/markdown-editor/scripts/utils/localSaver.js
@@ -1,0 +1,224 @@
+/**
+ * Local Storage Auto-Save
+ * Automatically saves content to localStorage with debouncing
+ */
+
+export class LocalSaver {
+    constructor(textareaId, storageKey = 'markdown-content') {
+        this.textarea = document.getElementById(textareaId);
+        this.storageKey = storageKey;
+        this.statusEl = document.getElementById('save-status');
+        this.saveTimeout = null;
+        this.debounceDelay = 1000; // 1 second
+
+        this.init();
+    }
+
+    init() {
+        // Load saved content on startup
+        this.loadContent();
+
+        // Listen for changes
+        this.textarea.addEventListener('input', () => {
+            this.scheduleAutoSave();
+        });
+
+        // Save on page unload
+        window.addEventListener('beforeunload', () => {
+            this.saveContent(true);
+        });
+    }
+
+    /**
+     * Schedule auto-save with debouncing
+     */
+    scheduleAutoSave() {
+        // Update status to "saving..."
+        if (this.statusEl) {
+            this.statusEl.textContent = 'Saving...';
+            this.statusEl.classList.add('saving');
+        }
+
+        // Clear existing timeout
+        if (this.saveTimeout) {
+            clearTimeout(this.saveTimeout);
+        }
+
+        // Schedule new save
+        this.saveTimeout = setTimeout(() => {
+            this.saveContent();
+        }, this.debounceDelay);
+    }
+
+    /**
+     * Save content to localStorage
+     */
+    saveContent(immediate = false) {
+        try {
+            const content = this.textarea.value;
+            const timestamp = Date.now();
+
+            const data = {
+                content,
+                timestamp,
+                version: 1
+            };
+
+            localStorage.setItem(this.storageKey, JSON.stringify(data));
+
+            // Update status
+            if (this.statusEl && !immediate) {
+                this.statusEl.textContent = 'All changes saved';
+                this.statusEl.classList.remove('saving');
+            }
+
+            return true;
+        } catch (error) {
+            console.error('Failed to save to localStorage:', error);
+
+            if (this.statusEl) {
+                this.statusEl.textContent = 'Save failed';
+                this.statusEl.classList.remove('saving');
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * Load content from localStorage
+     */
+    loadContent() {
+        try {
+            const saved = localStorage.getItem(this.storageKey);
+
+            if (!saved) return false;
+
+            const data = JSON.parse(saved);
+
+            if (data.content) {
+                this.textarea.value = data.content;
+
+                // Trigger input event to update preview
+                this.textarea.dispatchEvent(new Event('input'));
+
+                // Update status
+                if (this.statusEl) {
+                    const date = new Date(data.timestamp);
+                    this.statusEl.textContent = `Loaded from ${date.toLocaleString()}`;
+                }
+
+                return true;
+            }
+
+            return false;
+        } catch (error) {
+            console.error('Failed to load from localStorage:', error);
+            return false;
+        }
+    }
+
+    /**
+     * Clear saved content
+     */
+    clearSaved() {
+        try {
+            localStorage.removeItem(this.storageKey);
+            return true;
+        } catch (error) {
+            console.error('Failed to clear localStorage:', error);
+            return false;
+        }
+    }
+
+    /**
+     * Export current state as JSON
+     */
+    exportState() {
+        const content = this.textarea.value;
+        const timestamp = Date.now();
+
+        return {
+            content,
+            timestamp,
+            version: 1
+        };
+    }
+
+    /**
+     * Import state from JSON
+     */
+    importState(data) {
+        if (data && data.content) {
+            this.textarea.value = data.content;
+            this.textarea.dispatchEvent(new Event('input'));
+            this.saveContent();
+            return true;
+        }
+        return false;
+    }
+}
+
+/**
+ * Download Manager
+ * Handles markdown file downloads
+ */
+export class DownloadManager {
+    constructor() {
+        this.init();
+    }
+
+    init() {
+        const downloadBtn = document.getElementById('btn-download');
+        if (downloadBtn) {
+            downloadBtn.addEventListener('click', () => this.downloadMarkdown());
+        }
+    }
+
+    downloadMarkdown() {
+        const textarea = document.getElementById('markdown-input');
+        const content = textarea.value;
+
+        if (!content.trim()) {
+            alert('No content to download.');
+            return;
+        }
+
+        const filename = this.getSuggestedFilename();
+        this.downloadFile(content, filename, 'text/markdown');
+    }
+
+    getSuggestedFilename() {
+        const textarea = document.getElementById('markdown-input');
+        const firstLine = textarea.value.split('\n')[0];
+
+        // Try to extract title from first heading
+        const titleMatch = firstLine.match(/^#{1,6}\s+(.+)$/);
+        if (titleMatch) {
+            const title = titleMatch[1]
+                .replace(/[^a-z0-9]/gi, '-')
+                .toLowerCase()
+                .substring(0, 50);
+            return `${title}.md`;
+        }
+
+        const date = new Date().toISOString().split('T')[0];
+        return `document-${date}.md`;
+    }
+
+    downloadFile(content, filename, mimeType) {
+        const blob = new Blob([content], { type: mimeType });
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+
+        setTimeout(() => {
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }, 0);
+    }
+}

--- a/Tools/markdown-editor/scripts/utils/pdfExport.js
+++ b/Tools/markdown-editor/scripts/utils/pdfExport.js
@@ -1,0 +1,145 @@
+/**
+ * PDF Export Utility
+ * Triggers browser print dialog for PDF generation
+ */
+
+export class PDFExporter {
+    constructor() {
+        this.init();
+    }
+
+    init() {
+        const printBtn = document.getElementById('btn-print');
+        if (printBtn) {
+            printBtn.addEventListener('click', () => this.print());
+        }
+    }
+
+    /**
+     * Trigger print dialog
+     * User can save as PDF using browser's print-to-PDF functionality
+     */
+    print() {
+        // Check if there's content to print
+        const preview = document.getElementById('preview-content');
+
+        if (!preview || !preview.textContent.trim()) {
+            alert('No content to print. Please write something first.');
+            return;
+        }
+
+        // Trigger browser print dialog
+        window.print();
+    }
+
+    /**
+     * Generate filename suggestion based on first heading or date
+     */
+    getSuggestedFilename() {
+        const preview = document.getElementById('preview-content');
+        const firstHeading = preview.querySelector('h1, h2, h3');
+
+        if (firstHeading) {
+            const title = firstHeading.textContent
+                .replace(/[^a-z0-9]/gi, '-')
+                .toLowerCase()
+                .substring(0, 50);
+            return `${title}.pdf`;
+        }
+
+        const date = new Date().toISOString().split('T')[0];
+        return `markdown-${date}.pdf`;
+    }
+}
+
+/**
+ * HTML Export Utility
+ */
+export class HTMLExporter {
+    constructor() {
+        this.init();
+    }
+
+    init() {
+        const exportBtn = document.getElementById('btn-export-html');
+        if (exportBtn) {
+            exportBtn.addEventListener('click', () => this.export());
+        }
+    }
+
+    export() {
+        const preview = document.getElementById('preview-content');
+
+        if (!preview || !preview.textContent.trim()) {
+            alert('No content to export.');
+            return;
+        }
+
+        // Create standalone HTML document
+        const html = this.generateStandaloneHTML(preview.innerHTML);
+
+        // Trigger download
+        this.downloadFile(html, this.getSuggestedFilename(), 'text/html');
+    }
+
+    generateStandaloneHTML(content) {
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Markdown Export</title>
+    <style>
+        body {
+            max-width: 800px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1, h2 { border-bottom: 1px solid #eee; padding-bottom: 0.3em; }
+        code { background: #f4f4f4; padding: 2px 6px; border-radius: 3px; }
+        pre { background: #f4f4f4; padding: 1em; border-radius: 6px; overflow-x: auto; }
+        blockquote { border-left: 4px solid #ddd; padding-left: 1em; color: #666; }
+        img { max-width: 100%; }
+    </style>
+</head>
+<body>
+${content}
+</body>
+</html>`;
+    }
+
+    downloadFile(content, filename, mimeType) {
+        const blob = new Blob([content], { type: mimeType });
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+
+        setTimeout(() => {
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }, 0);
+    }
+
+    getSuggestedFilename() {
+        const preview = document.getElementById('preview-content');
+        const firstHeading = preview.querySelector('h1, h2, h3');
+
+        if (firstHeading) {
+            const title = firstHeading.textContent
+                .replace(/[^a-z0-9]/gi, '-')
+                .toLowerCase()
+                .substring(0, 50);
+            return `${title}.html`;
+        }
+
+        const date = new Date().toISOString().split('T')[0];
+        return `markdown-${date}.html`;
+    }
+}

--- a/Tools/markdown-editor/styles/editor.css
+++ b/Tools/markdown-editor/styles/editor.css
@@ -1,0 +1,382 @@
+:root {
+    --bg-primary: #ffffff;
+    --bg-secondary: #f8f9fa;
+    --bg-tertiary: #e9ecef;
+    --border-color: #dee2e6;
+    --text-primary: #212529;
+    --text-secondary: #6c757d;
+    --accent: #0d6efd;
+    --accent-hover: #0b5ed7;
+    --success: #198754;
+    --code-bg: #f8f9fa;
+    --shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Inter', sans-serif;
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    height: 100vh;
+    overflow: hidden;
+}
+
+.app-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+/* Header */
+.editor-header {
+    background-color: var(--bg-primary);
+    border-bottom: 1px solid var(--border-color);
+    padding: 0.75rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    box-shadow: var(--shadow);
+    z-index: 10;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.brand i {
+    font-size: 1.5rem;
+    color: var(--accent);
+}
+
+.brand h1 {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.auto-save-status {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin-left: 1rem;
+}
+
+.auto-save-status.saving {
+    color: var(--accent);
+}
+
+/* Toolbar */
+.toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.toolbar-group {
+    display: flex;
+    gap: 0.25rem;
+}
+
+.toolbar-divider {
+    width: 1px;
+    height: 24px;
+    background-color: var(--border-color);
+}
+
+.tool-btn {
+    background: transparent;
+    border: 1px solid transparent;
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+}
+
+.tool-btn:hover {
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    border-color: var(--border-color);
+}
+
+.tool-btn:active {
+    transform: scale(0.95);
+}
+
+.btn-action {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: all 0.2s;
+    font-weight: 500;
+}
+
+.btn-action:hover {
+    background-color: var(--bg-tertiary);
+}
+
+.btn-primary {
+    background-color: var(--accent);
+    border: 1px solid var(--accent);
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: white;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: all 0.2s;
+    font-weight: 500;
+}
+
+.btn-primary:hover {
+    background-color: var(--accent-hover);
+}
+
+/* Workspace */
+.editor-workspace {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+}
+
+.editor-pane,
+.preview-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--bg-primary);
+    min-width: 300px;
+}
+
+.pane-header {
+    background-color: var(--bg-secondary);
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.editor-stats {
+    display: flex;
+    gap: 1rem;
+    font-size: 0.75rem;
+    font-weight: 400;
+}
+
+.sync-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    font-weight: normal;
+}
+
+.sync-toggle input[type="checkbox"] {
+    cursor: pointer;
+}
+
+/* Editor Textarea */
+#markdown-input {
+    flex: 1;
+    border: none;
+    resize: none;
+    padding: 2rem;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+    line-height: 1.6;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    overflow-y: auto;
+}
+
+#markdown-input:focus {
+    outline: none;
+}
+
+/* Preview */
+#preview-content {
+    flex: 1;
+    padding: 2rem;
+    overflow-y: auto;
+    background-color: var(--bg-primary);
+}
+
+.placeholder {
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+/* Markdown Styling */
+.markdown-body {
+    font-size: 16px;
+    line-height: 1.6;
+    font-family: 'Inter', sans-serif;
+}
+
+.markdown-body h1 {
+    font-size: 2em;
+    font-weight: 700;
+    margin: 0.67em 0;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.3em;
+}
+
+.markdown-body h2 {
+    font-size: 1.5em;
+    font-weight: 600;
+    margin: 0.83em 0;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.3em;
+}
+
+.markdown-body h3 {
+    font-size: 1.25em;
+    font-weight: 600;
+    margin: 1em 0;
+}
+
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+    font-weight: 600;
+    margin: 1em 0;
+}
+
+.markdown-body p {
+    margin: 1em 0;
+}
+
+.markdown-body a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.markdown-body a:hover {
+    text-decoration: underline;
+}
+
+.markdown-body strong {
+    font-weight: 700;
+}
+
+.markdown-body em {
+    font-style: italic;
+}
+
+.markdown-body del {
+    text-decoration: line-through;
+}
+
+.markdown-body code {
+    background-color: var(--code-bg);
+    padding: 0.2em 0.4em;
+    border-radius: 3px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 85%;
+}
+
+.markdown-body pre {
+    background-color: var(--code-bg);
+    padding: 1em;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 1em 0;
+}
+
+.markdown-body pre code {
+    background: none;
+    padding: 0;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+    margin: 1em 0;
+    padding-left: 2em;
+}
+
+.markdown-body li {
+    margin: 0.5em 0;
+}
+
+.markdown-body blockquote {
+    border-left: 4px solid var(--border-color);
+    padding-left: 1em;
+    margin: 1em 0;
+    color: var(--text-secondary);
+}
+
+.markdown-body hr {
+    border: none;
+    border-top: 2px solid var(--border-color);
+    margin: 2em 0;
+}
+
+.markdown-body img {
+    max-width: 100%;
+    height: auto;
+}
+
+/* Resize Divider */
+.resize-divider {
+    width: 8px;
+    background-color: var(--bg-secondary);
+    cursor: col-resize;
+    position: relative;
+    transition: background-color 0.2s;
+}
+
+.resize-divider:hover {
+    background-color: var(--accent);
+}
+
+.resize-divider::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 2px;
+    height: 40px;
+    background-color: var(--border-color);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: var(--bg-secondary);
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--border-color);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--text-secondary);
+}

--- a/Tools/markdown-editor/styles/print.css
+++ b/Tools/markdown-editor/styles/print.css
@@ -1,0 +1,71 @@
+/* Print / PDF Export Styles */
+
+@media print {
+
+    /* Hide UI elements */
+    .editor-header,
+    .pane-header,
+    .editor-pane,
+    .resize-divider {
+        display: none !important;
+    }
+
+    /* Make preview full width */
+    .preview-pane {
+        width: 100% !important;
+        max-width: none !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        border: none !important;
+    }
+
+    #preview-content {
+        padding: 0.5in !important;
+    }
+
+    /* Reset colors for print */
+    body {
+        background: white !important;
+        color: black !important;
+    }
+
+    .markdown-body {
+        color: black !important;
+    }
+
+    /* Page breaks */
+    .markdown-body h1,
+    .markdown-body h2,
+    .markdown-body h3 {
+        page-break-after: avoid;
+    }
+
+    .markdown-body pre,
+    .markdown-body blockquote {
+        page-break-inside: avoid;
+    }
+
+    /* Links */
+    .markdown-body a {
+        text-decoration: underline;
+        color: black !important;
+    }
+
+    .markdown-body a[href^="http"]:after {
+        content: " (" attr(href) ")";
+        font-size: 0.8em;
+        font-style: italic;
+    }
+
+    /* Code blocks */
+    .markdown-body pre {
+        border: 1px solid #ccc;
+        page-break-inside: avoid;
+    }
+
+    /* Images */
+    .markdown-body img {
+        max-width: 100%;
+        page-break-inside: avoid;
+    }
+}


### PR DESCRIPTION
- Created standalone Markdown editor in Tools/markdown-editor/
- Implemented custom Regex-based Markdown parser (no libraries)
- Added live preview with synchronized scrolling
- Implemented PDF export (via print) and standalone HTML export
- Added toolbar with common formatting actions and keyboard shortcuts
- Implemented debounced auto-save to localStorage
- Organized project under root Tools/ directory per maintainer instructions


closes #1311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a complete Markdown editor with a split layout featuring a live preview pane.
  * Added formatting toolbar with actions for bold, italic, strikethrough, headings, links, images, code blocks, lists, and quotes.
  * Implemented auto-save functionality to preserve content automatically.
  * Added export options: download as Markdown, export to HTML, and print to PDF.
  * Enabled synchronized scrolling between editor and preview panes.
  * Included live word and character counters.
  * Added resizable split pane divider and Tab indentation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->