### PR TITLE
[ECWoC] Double entry of project 152

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -1621,17 +1621,7 @@
     "folder": "Day 154 ",
     "level": "CAPSTONE"
   },
-  {
-    "day": 152,
-    "title": "Newsly",
-    "tech": [
-      "HTML",
-      "CSS",
-      "JS"
-    ],
-    "folder": "Day 152 - Newsly",
-    "level": "CAPSTONE"
-  },
+  
   {
     "day": 155,
     "title": "Tetris Game",


### PR DESCRIPTION
Earlier, there was a double entry of project 152 - newsly on https://100dayswebdevelopment-ecwoc.netlify.app/website/pages/projects.html due to a duplicate entry in projects.json (only a single entry was in project.js)

Fixed it by removing the second entry

earlier:
<img width="1625" height="807" alt="image" src="https://github.com/user-attachments/assets/45eb6ce6-a4d2-48d3-abdd-dcaa63c50037" />
now:
<img width="1588" height="685" alt="image" src="https://github.com/user-attachments/assets/f7f788ad-8008-49be-80eb-275f8f888ee0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project collection: Removed Newsly, added Tetris Game, and restored Time Fracture Arena.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->